### PR TITLE
fix: update config.js (default -> testnet)

### DIFF
--- a/server/utils/near-utils.js
+++ b/server/utils/near-utils.js
@@ -1,34 +1,50 @@
-const fs = require('fs');
-const nearAPI = require('near-api-js');
-const getConfig = require('../../src/config');
-const { nodeUrl, networkId, contractName, contractMethods } = getConfig(true);
+const fs = require("fs");
+const nearAPI = require("near-api-js");
+const getConfig = require("../../src/config");
+const { nodeUrl, networkId, CONTRACT_NAME, contractMethods } = getConfig(true);
 const {
-	keyStores: { InMemoryKeyStore },
-	Near, Account, Contract, KeyPair,
-	utils: {
-		format: {
-			parseNearAmount
-		}
-	}
+  keyStores: { InMemoryKeyStore },
+  Near,
+  Account,
+  Contract,
+  KeyPair,
+  utils: {
+    format: { parseNearAmount },
+  },
 } = nearAPI;
 
-const credentials = JSON.parse(fs.readFileSync(process.env.HOME + '/.near-credentials/testnet/' + contractName + '.json'));
+const credentials = JSON.parse(
+  fs.readFileSync(
+    process.env.HOME + "/.near-credentials/testnet/" + CONTRACT_NAME + ".json"
+  )
+);
 const keyStore = new InMemoryKeyStore();
-keyStore.setKey(networkId, contractName, KeyPair.fromString(credentials.private_key));
+keyStore.setKey(
+  networkId,
+  CONTRACT_NAME,
+  KeyPair.fromString(credentials.private_key)
+);
 const near = new Near({
-	networkId, nodeUrl,
-	deps: { keyStore },
+  networkId,
+  nodeUrl,
+  deps: { keyStore },
 });
 const { connection } = near;
-const contractAccount = new Account(connection, contractName);
-contractAccount.addAccessKey = (publicKey) => contractAccount.addKey(publicKey, contractName, contractMethods.changeMethods, parseNearAmount('0.1'));
-const contract = new Contract(contractAccount, contractName, contractMethods);
+const contractAccount = new Account(connection, CONTRACT_NAME);
+contractAccount.addAccessKey = (publicKey) =>
+  contractAccount.addKey(
+    publicKey,
+    CONTRACT_NAME,
+    contractMethods.changeMethods,
+    parseNearAmount("0.1")
+  );
+const contract = new Contract(contractAccount, CONTRACT_NAME, contractMethods);
 
 module.exports = {
-	near,
-	keyStore,
-	connection,
-	contract,
-	contractName,
-	contractAccount,
+  near,
+  keyStore,
+  connection,
+  contract,
+  CONTRACT_NAME,
+  contractAccount,
 };

--- a/server/utils/near-utils.js
+++ b/server/utils/near-utils.js
@@ -12,7 +12,7 @@ const {
 	}
 } = nearAPI;
 
-const credentials = JSON.parse(fs.readFileSync(process.env.HOME + '/.near-credentials/default/' + contractName + '.json'));
+const credentials = JSON.parse(fs.readFileSync(process.env.HOME + '/.near-credentials/testnet/' + contractName + '.json'));
 const keyStore = new InMemoryKeyStore();
 keyStore.setKey(networkId, contractName, KeyPair.fromString(credentials.private_key));
 const near = new Near({

--- a/server/utils/near-utils.js
+++ b/server/utils/near-utils.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const nearAPI = require("near-api-js");
 const getConfig = require("../../src/config");
-const { nodeUrl, networkId, CONTRACT_NAME, contractMethods } = getConfig(true);
+const { nodeUrl, networkId, contractName, contractMethods } = getConfig(true);
 const {
   keyStores: { InMemoryKeyStore },
   Near,
@@ -15,13 +15,13 @@ const {
 
 const credentials = JSON.parse(
   fs.readFileSync(
-    process.env.HOME + "/.near-credentials/testnet/" + CONTRACT_NAME + ".json"
+    process.env.HOME + "/.near-credentials/testnet/" + contractName + ".json"
   )
 );
 const keyStore = new InMemoryKeyStore();
 keyStore.setKey(
   networkId,
-  CONTRACT_NAME,
+  contractName,
   KeyPair.fromString(credentials.private_key)
 );
 const near = new Near({
@@ -30,21 +30,21 @@ const near = new Near({
   deps: { keyStore },
 });
 const { connection } = near;
-const contractAccount = new Account(connection, CONTRACT_NAME);
+const contractAccount = new Account(connection, contractName);
 contractAccount.addAccessKey = (publicKey) =>
   contractAccount.addKey(
     publicKey,
-    CONTRACT_NAME,
+    contractName,
     contractMethods.changeMethods,
     parseNearAmount("0.1")
   );
-const contract = new Contract(contractAccount, CONTRACT_NAME, contractMethods);
+const contract = new Contract(contractAccount, contractName, contractMethods);
 
 module.exports = {
   near,
   keyStore,
   connection,
   contract,
-  CONTRACT_NAME,
+  contractName,
   contractAccount,
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,36 +1,36 @@
-const contractName = 'dev-1613016656902-5605325';
+const CONTRACT_NAME = "dev-1613016656902-5605325";
 
 module.exports = function getConfig(isServer = false) {
-	let config = {
-		networkId: 'default',
-		nodeUrl: 'https://rpc.testnet.near.org',
-		walletUrl: 'https://wallet.testnet.near.org',
-		helperUrl: 'https://helper.testnet.near.org',
-		contractName,
-	};
-    
-	if (process.env.REACT_APP_ENV !== undefined) {
-		config = {
-			...config,
-			GAS: '200000000000000',
-			DEFAULT_NEW_ACCOUNT_AMOUNT: '20',
-			contractMethods: {
-				changeMethods: ['new', 'subscribe', 'ping', 'withdraw'],
-				viewMethods: ['get_subs'],
-			},
-		};
-	}
-    
-	if (process.env.REACT_APP_ENV === 'prod') {
-		config = {
-			...config,
-			networkId: 'mainnet',
-			nodeUrl: 'https://rpc.mainnet.near.org',
-			walletUrl: 'https://wallet.near.org',
-			helperUrl: 'https://helper.mainnet.near.org',
-			contractName: 'near',
-		};
-	}
+  let config = {
+    networkId: "main",
+    nodeUrl: "https://rpc.testnet.near.org",
+    walletUrl: "https://wallet.testnet.near.org",
+    helperUrl: "https://helper.testnet.near.org",
+    CONTRACT_NAME,
+  };
 
-	return config;
+  if (process.env.REACT_APP_ENV !== undefined) {
+    config = {
+      ...config,
+      GAS: "200000000000000",
+      DEFAULT_NEW_ACCOUNT_AMOUNT: "20",
+      contractMethods: {
+        changeMethods: ["new", "subscribe", "ping", "withdraw"],
+        viewMethods: ["get_subs"],
+      },
+    };
+  }
+
+  if (process.env.REACT_APP_ENV === "prod") {
+    config = {
+      ...config,
+      networkId: "mainnet",
+      nodeUrl: "https://rpc.mainnet.near.org",
+      walletUrl: "https://wallet.near.org",
+      helperUrl: "https://helper.mainnet.near.org",
+      CONTRACT_NAME: "near",
+    };
+  }
+
+  return config;
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,12 +1,12 @@
-const CONTRACT_NAME = "dev-1613016656902-5605325";
+const contractName = 'dev-1621300129725-91447793846989';
 
 module.exports = function getConfig(isServer = false) {
   let config = {
-    networkId: "main",
+    networkId: "testnet",
     nodeUrl: "https://rpc.testnet.near.org",
     walletUrl: "https://wallet.testnet.near.org",
     helperUrl: "https://helper.testnet.near.org",
-    CONTRACT_NAME,
+    contractName,
   };
 
   if (process.env.REACT_APP_ENV !== undefined) {
@@ -28,7 +28,7 @@ module.exports = function getConfig(isServer = false) {
       nodeUrl: "https://rpc.mainnet.near.org",
       walletUrl: "https://wallet.near.org",
       helperUrl: "https://helper.mainnet.near.org",
-      CONTRACT_NAME: "near",
+      contractName: "near",
     };
   }
 

--- a/test/near-utils.js
+++ b/test/near-utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const nearAPI = require('near-api-js');
 const getConfig = require('../src/config');
-const { nodeUrl, networkId, CONTRACT_NAME, contractMethods } = getConfig(true);
+const { nodeUrl, networkId, contractName, contractMethods } = getConfig(true);
 const {
 	keyStores: { InMemoryKeyStore },
 	Near, Account, Contract, KeyPair,
@@ -12,23 +12,23 @@ const {
 	}
 } = nearAPI;
 
-const credentials = JSON.parse(fs.readFileSync(process.env.HOME + '/.near-credentials/testnet/' + CONTRACT_NAME + '.json'));
+const credentials = JSON.parse(fs.readFileSync(process.env.HOME + '/.near-credentials/testnet/' + contractName + '.json'));
 const keyStore = new InMemoryKeyStore();
-keyStore.setKey(networkId, CONTRACT_NAME, KeyPair.fromString(credentials.private_key));
+keyStore.setKey(networkId, contractName, KeyPair.fromString(credentials.private_key));
 const near = new Near({
 	networkId, nodeUrl,
 	deps: { keyStore },
 });
 const { connection } = near;
-const contractAccount = new Account(connection, CONTRACT_NAME);
-contractAccount.addAccessKey = (publicKey) => contractAccount.addKey(publicKey, CONTRACT_NAME, contractMethods.changeMethods, parseNearAmount('0.1'));
-const contract = new Contract(contractAccount, CONTRACT_NAME, contractMethods);
+const contractAccount = new Account(connection, contractName);
+contractAccount.addAccessKey = (publicKey) => contractAccount.addKey(publicKey, contractName, contractMethods.changeMethods, parseNearAmount('0.1'));
+const contract = new Contract(contractAccount, contractName, contractMethods);
 
 module.exports = {
 	near,
 	keyStore,
 	connection,
 	contract,
-	CONTRACT_NAME,
+	contractName,
 	contractAccount,
 };

--- a/test/near-utils.js
+++ b/test/near-utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const nearAPI = require('near-api-js');
 const getConfig = require('../src/config');
-const { nodeUrl, networkId, contractName, contractMethods } = getConfig(true);
+const { nodeUrl, networkId, CONTRACT_NAME, contractMethods } = getConfig(true);
 const {
 	keyStores: { InMemoryKeyStore },
 	Near, Account, Contract, KeyPair,
@@ -12,23 +12,23 @@ const {
 	}
 } = nearAPI;
 
-const credentials = JSON.parse(fs.readFileSync(process.env.HOME + '/.near-credentials/testnet/' + contractName + '.json'));
+const credentials = JSON.parse(fs.readFileSync(process.env.HOME + '/.near-credentials/testnet/' + CONTRACT_NAME + '.json'));
 const keyStore = new InMemoryKeyStore();
-keyStore.setKey(networkId, contractName, KeyPair.fromString(credentials.private_key));
+keyStore.setKey(networkId, CONTRACT_NAME, KeyPair.fromString(credentials.private_key));
 const near = new Near({
 	networkId, nodeUrl,
 	deps: { keyStore },
 });
 const { connection } = near;
-const contractAccount = new Account(connection, contractName);
-contractAccount.addAccessKey = (publicKey) => contractAccount.addKey(publicKey, contractName, contractMethods.changeMethods, parseNearAmount('0.1'));
-const contract = new Contract(contractAccount, contractName, contractMethods);
+const contractAccount = new Account(connection, CONTRACT_NAME);
+contractAccount.addAccessKey = (publicKey) => contractAccount.addKey(publicKey, CONTRACT_NAME, contractMethods.changeMethods, parseNearAmount('0.1'));
+const contract = new Contract(contractAccount, CONTRACT_NAME, contractMethods);
 
 module.exports = {
 	near,
 	keyStore,
 	connection,
 	contract,
-	contractName,
+	CONTRACT_NAME,
 	contractAccount,
 };

--- a/test/near-utils.js
+++ b/test/near-utils.js
@@ -12,7 +12,7 @@ const {
 	}
 } = nearAPI;
 
-const credentials = JSON.parse(fs.readFileSync(process.env.HOME + '/.near-credentials/default/' + contractName + '.json'));
+const credentials = JSON.parse(fs.readFileSync(process.env.HOME + '/.near-credentials/testnet/' + contractName + '.json'));
 const keyStore = new InMemoryKeyStore();
 keyStore.setKey(networkId, contractName, KeyPair.fromString(credentials.private_key));
 const near = new Near({


### PR DESCRIPTION
- Updated `config.js` to use `testnet` as `default` is now deprecated.
- Changed `contractName` variable to `CONTRACT_NAME`.
- Formatting
